### PR TITLE
Versions json

### DIFF
--- a/latest_links/version-info.json
+++ b/latest_links/version-info.json
@@ -1,0 +1,15 @@
+{
+    "supported_lts_releases": [
+        8,
+        11,
+        17
+    ],
+    "supported_feature_releases": [
+        19
+    ],
+    "end_of_life_releases": [
+        15,
+        16,
+        18
+    ]
+}


### PR DESCRIPTION
Adding a simple json file container the supported LTS and FRs, as well as a list of EOL versions. This should cover what is needed for https://github.com/corretto/corretto-downloads/issues/3

I'm trying not to repeat versions in this file, so nothing will be listed more than once. The latest version will be the last one listed which will also always be the highest number.